### PR TITLE
desktop breaking change warning

### DIFF
--- a/src/nightly/index.html
+++ b/src/nightly/index.html
@@ -104,6 +104,8 @@
 										${NIX_URL}
 									</a>
 									<br /><br />
+									<p style="color:red">WARNING! BREAKING CHANGE OCT 22. Action required. <a href="https://discuss.status.im/t/living-our-principles-drinking-our-own-champagne-saying-goodbye-to-slack-and-hello-to-status/407/9?u=chad" target="_blank">Read before updating.</a></p>
+									<br /><br />
 									<a href="https://goo.gl/NB9n81" target="_blank">
 										Desktop FAQ
 									</a>
@@ -123,6 +125,8 @@
 									<a href="${DMG_URL}" target="_blank">
 										${DMG_URL}
 									</a>
+									<br /><br />
+									<p style="color:red">WARNING! BREAKING CHANGE OCT 22. Action required. <a href="https://discuss.status.im/t/living-our-principles-drinking-our-own-champagne-saying-goodbye-to-slack-and-hello-to-status/407/9?u=chad" target="_blank">Read before updating.</a></p>
 									<br /><br />
 									<a href="https://goo.gl/NB9n81" target="_blank">
 										Desktop FAQ


### PR DESCRIPTION
Adding a breaking change warning linking to [instructions](https://discuss.status.im/t/living-our-principles-drinking-our-own-champagne-saying-goodbye-to-slack-and-hello-to-status/407/9?u=chad) on how to fix.

<img width="286" alt="screen shot 2018-10-22 at 8 51 30 am" src="https://user-images.githubusercontent.com/116099/47280645-b5d32a00-d5d7-11e8-999e-bc8be969957b.png">
